### PR TITLE
Fixes the build by explicitly including libcore

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,12 @@
 
 //! A typesafe bitmask flag generator.
 
+#![feature(no_std)]
+
 #![no_std]
 #[cfg(test)] #[macro_use] extern crate std;
+
+extern crate core;
 
 /// The `bitflags!` macro generates a `struct` that holds a set of C-style
 /// bitmask flags. It is useful for creating typesafe wrappers for C APIs.


### PR DESCRIPTION
Fixes so it compiles again; not sure why this wasn't broken before, but I presume its to do with feature flag updates.